### PR TITLE
Change version of go from 1.21.0 to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Real-Dev-Squad/tiny-site-backend
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
Developer Name: @vinit717 

Description : 

In this PR we are changing  the version of Go from 1.21.0 to 1.21 because the deployment services doest take that version in consideration

PR Number(s):-
- #21

Backend changes
Yes


Frontend Changes
No

Is Under Feature Flag 
No

Database changes
No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
No

Deployment notes
Change version for deployment only

Tested in staging
No

