### PR TITLE
Fix token expiration issue

### DIFF
--- a/environments/dev.env
+++ b/environments/dev.env
@@ -1,7 +1,7 @@
 JWT_SECRET="secret"
-JWT_VALIDITY_IN_HOURS=24
+JWT_VALIDITY_IN_HOURS=8760
 JWT_ISSUER="tiny-site-backend"
-
+PORT="8000"
 DOMAIN="localhost"
 AUTH_REDIRECT_URL="http://localhost:3000/dashboard"
 

--- a/tests/unit/jwt_test.go
+++ b/tests/unit/jwt_test.go
@@ -33,21 +33,51 @@ func TestGenerateJWT(t *testing.T) {
 }
 
 func TestVerifyJWT(t *testing.T) {
+	t.Run("ValidToken", func(t *testing.T) {
+		dummyUser := &models.User{
+			Email: "test@gmail.com",
+		}
+
+		validToken, generateTokenError := utils.GenerateToken(dummyUser)
+
+		if generateTokenError != nil {
+			t.Fatalf("Error: %v", generateTokenError)
+		}
+
+		email, validTokenError := utils.VerifyToken(validToken)
+
+		if validTokenError != nil {
+			t.Fatalf("Error: %v", validTokenError)
+		}
+
+		if email != dummyUser.Email {
+			t.Fatalf("Expected %v but got %v", dummyUser.Email, email)
+		}
+	})
+
+	t.Run("ExpiredToken", func(t *testing.T) {
+		expiredToken := "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RAZ21haWwuY29tIiwiZXhwIjoiMjAyMy0xMC0wMVQxOTo1Njo0OS4zOTc5NzEyWiIsImlzcyI6Indpc2VlLWJhY2tlbmQifQ.h11JtaPg-ITKR8UXTyz_Q7pJU_3gYyXwIkqX7lI1UK2nVkvxQvkyN23-u3wj8fV5mNIvp-ePTOp-7odsPcGC_g"
+
+		_, expiredTokenError := utils.VerifyToken(expiredToken)
+
+		if expiredTokenError == nil {
+			t.Fatalf("Expected error but got nil")
+		}
+	})
+}
+
+func TestVerifyJWTForOneYear(t *testing.T) {
+	os.Setenv("JWT_VALIDITY_IN_HOURS", "8760")
+	defer os.Setenv("JWT_VALIDITY_IN_HOURS", "24")
+
 	dummyUser := &models.User{
 		Email: "test@gmail.com",
 	}
 
 	validToken, generateTokenError := utils.GenerateToken(dummyUser)
-	expiredToken := "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RAZ21haWwuY29tIiwiZXhwIjoiMjAyMy0xMC0wMVQxOTo1Njo0OS4zOTc5NzEyWiIsImlzcyI6Indpc2VlLWJhY2tlbmQifQ.h11JtaPg-ITKR8UXTyz_Q7pJU_3gYyXwIkqX7lI1UK2nVkvxQvkyN23-u3wj8fV5mNIvp-ePTOp-7odsPcGC_g"
 
 	if generateTokenError != nil {
 		t.Fatalf("Error: %v", generateTokenError)
-	}
-
-	_, expiredTokenError := utils.VerifyToken(expiredToken)
-
-	if expiredTokenError == nil {
-		t.Fatalf("Expected error but got nil")
 	}
 
 	email, validTokenError := utils.VerifyToken(validToken)

--- a/utils/jwt.go
+++ b/utils/jwt.go
@@ -17,13 +17,12 @@ func GenerateToken(user *models.User) (string, error) {
 	issuer := os.Getenv("JWT_ISSUER")
 	key := []byte(os.Getenv("JWT_SECRET"))
 
-	tokenValidityInHours, err := strconv.ParseInt(os.Getenv("JWT_VALIDITY_IN_HOURS"), 10, 8)
-
+	tokenValidityInHours, err := strconv.ParseInt(os.Getenv("JWT_VALIDITY_IN_HOURS"), 10, 64)
 	if err != nil {
 		return "", err
 	}
 
-	tokenExpiryTime := time.Now().Add(time.Second * time.Duration(tokenValidityInHours)).UTC().Format(time.RFC3339)
+	tokenExpiryTime := time.Now().Add(time.Duration(tokenValidityInHours) * time.Hour).UTC().Format(time.RFC3339)
 
 	t := jwt.NewWithClaims(jwt.SigningMethodHS512, jwt.MapClaims{
 		"iss":   issuer,


### PR DESCRIPTION
**Closes** #27
### **Description:**
This pull request (PR) addresses the issue of token expiration and extends the token validity duration. The PR includes changes to both token generation and verification logic. Specifically, it allows tokens to be valid for up to one year, providing an improved user experience by reducing the need for frequent re-authentication.

### **Key Changes:**

**Token Generation Enhancement:**
Updated the GenerateToken function to accept a new environment variable JWT_VALIDITY_IN_HOURS, which is used to specify the token's validity duration in hours.
Modified the calculation of token expiration time to use the value from JWT_VALIDITY_IN_HOURS.

**Token Verification Enhancement:**
Adjusted the VerifyToken function to handle the new token format and correctly parse the expiration time.
Extended the testing suite to cover token validity for both the default and one-year duration cases.

- By extending the token validity to one year, this enhancement significantly improves user experience by reducing the frequency of re-authentication, especially for long-lasting user sessions.


![image](https://github.com/Real-Dev-Squad/tiny-site-backend/assets/111434418/722d22fd-3920-4dc6-a5a8-ae8fb7cccd32)
![image](https://github.com/Real-Dev-Squad/tiny-site-backend/assets/111434418/4826c6b2-d93b-4527-95b3-6e64dc666ff9)
