### PR TITLE
feat: new api for get shorten url details

### DIFF
--- a/controllers/url.go
+++ b/controllers/url.go
@@ -68,3 +68,47 @@ func RedirectShortURL(ctx *gin.Context, db *bun.DB) {
 
 	ctx.Redirect(http.StatusMovedPermanently, tinyURL.OriginalUrl)
 }
+
+func GetAllURLs(ctx *gin.Context, db *bun.DB) {
+	userID := ctx.Param("id")
+	var tinyURL []models.Tinyurl
+
+	err := db.NewSelect().
+		Model(&tinyURL).
+		Where("user_id = ?", userID).
+		Scan(ctx, &tinyURL)
+
+	if err != nil {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"message": "No URLs found for the user",
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message": "All URLs fetched successfully",
+		"urls":    tinyURL,
+	})
+}
+
+func GetURLDetails(ctx *gin.Context, db *bun.DB) {
+	shortURL := ctx.Param("shortURL")
+	var tinyURL models.Tinyurl
+
+	err := db.NewSelect().
+		Model(&tinyURL).
+		Where("short_url = ?", shortURL).
+		Scan(ctx, &tinyURL)
+
+	if err != nil {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"message": "No URLs found for the user",
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message": "URL fetched successfully",
+		"url":     tinyURL,
+	})
+}

--- a/routes/url.go
+++ b/routes/url.go
@@ -8,6 +8,7 @@ import (
 
 func TinyURLRoutes(rg *gin.RouterGroup, db *bun.DB) {
 	tinyURL := rg.Group("/tinyurl")
+	urls := rg.Group("/urls")
 
 	tinyURL.POST("", func(ctx *gin.Context) {
 		controller.CreateTinyURL(ctx, db)
@@ -15,5 +16,9 @@ func TinyURLRoutes(rg *gin.RouterGroup, db *bun.DB) {
 
 	tinyURL.GET("/:shortURL", func(ctx *gin.Context) {
 		controller.RedirectShortURL(ctx, db)
+	})
+
+	urls.GET("/:shortURL", func(ctx *gin.Context) {
+		controller.GetURLDetails(ctx, db)
 	})
 }

--- a/routes/users.go
+++ b/routes/users.go
@@ -8,8 +8,11 @@ import (
 )
 
 func UserRoutes(rg *gin.RouterGroup, db *bun.DB) {
+
     users := rg.Group("/users")
+    user := rg.Group("/user")
     users.Use(middleware.AuthMiddleware())
+    user.Use(middleware.AuthMiddleware())
 
     users.GET("", func(ctx *gin.Context) {
         controller.GetUserList(ctx, db)
@@ -22,4 +25,8 @@ func UserRoutes(rg *gin.RouterGroup, db *bun.DB) {
     users.GET("/self", func(ctx *gin.Context) {
         controller.GetSelfUser(ctx, db)
     })
+
+    user.GET("/:id/urls", func(ctx *gin.Context) {
+		controller.GetAllURLs(ctx, db)
+	})
 }

--- a/tests/integration/url_test.go
+++ b/tests/integration/url_test.go
@@ -66,5 +66,28 @@ func setupTestRouter() *gin.Engine {
 	router.POST("/v1/create-tinyurl", func(ctx *gin.Context) {
 		controller.CreateTinyURL(ctx, db)
 	})
+	router.GET("/v1/tinyurl/:shortUrl", func(ctx *gin.Context) {
+		controller.GetURLDetails(ctx, db)
+	})
 	return router
+}
+
+func TestGetUrlDetails(t *testing.T) {
+	router := setupTestRouter()
+	w := httptest.NewRecorder()
+
+	testShortURL := "37fff02c"
+	expectedOriginalURL := "https://react.dev/learn/"
+
+	req, _ := http.NewRequest("GET", "/v1/tinyurl/"+testShortURL, nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Errorf("Expected status %d, got %d", http.StatusMovedPermanently, w.Code)
+	}
+
+	locationHeader := w.Header().Get("Location")
+	if locationHeader != expectedOriginalURL {
+		t.Errorf("Expected Location header %q, got %q", expectedOriginalURL, locationHeader)
+	}
 }

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -95,3 +95,21 @@ func TestGetUserByIdUnauthorized(t *testing.T) {
 		t.Errorf("Expected status code %d but got %d", http.StatusUnauthorized, w.Code)
 	}
 }
+
+func TestGetUrlsByUserIdUnauthorized(t *testing.T) {
+	router := routes.SetupV1Routes(db)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/v1/user/1/urls", nil)
+
+	req.Header.Set("Authorization", "Bearer invalid_token")
+	router.ServeHTTP(w, req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code %d but got %d", http.StatusUnauthorized, w.Code)
+	}
+}


### PR DESCRIPTION
## Description

This pull request introduces a new API feature that enhances our URL shortening service by providing two key functionalities:

1. **Get Shortened URL Details API:** This API allows users to retrieve detailed information about a specific shortened URL. It provides insights into the original URL, creation date, click statistics, and any custom alias associated with the shortened URL.

2. **Get All URLs Created by User API:** This API enables users to obtain a list of all URLs they have created using our service, based on their user ID.
