### PR TITLE
Add Url count for track

### DIFF
--- a/cmd/bun/migrations/20240215113820_initial-setup.up.sql
+++ b/cmd/bun/migrations/20240215113820_initial-setup.up.sql
@@ -12,6 +12,7 @@ CREATE TABLE users (
   updated_at timestamp DEFAULT (NOW() AT TIME ZONE 'UTC'),
   is_deleted boolean DEFAULT false,
   is_onboarding BOOLEAN NOT NULL DEFAULT TRUE
+  url_count int NOT NULL DEFAULT 0
 );
 
 --bun:split

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -31,6 +31,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
+	// Check if URL already exists
 	var existingOriginalURL models.Tinyurl
 	if err := db.NewSelect().Model(&existingOriginalURL).
 		Where("original_url = ?", body.OriginalUrl).
@@ -40,10 +41,12 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		ctx.JSON(http.StatusOK, dtos.URLCreationResponse{
 			Message:  "Shortened URL already exists",
 			ShortURL: existingOriginalURL.ShortUrl,
+			CreatedAt: existingOriginalURL.CreatedAt,
 		})
 		return
 	}
 
+	// Validate custom short URL
 	if body.ShortUrl != "" {
 		if len(body.ShortUrl) < 5 {
 			ctx.JSON(http.StatusBadRequest, dtos.URLCreationResponse{
@@ -73,6 +76,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		}
 	}
 
+	// Count URLs for the user
 	count, err := db.NewSelect().
 		Model(&models.Tinyurl{}).
 		Where("user_id = ?", body.UserID).
@@ -85,7 +89,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		})
 		return
 	}
-	body.CreatedAt = time.Now().UTC()
 
 	if count >= config.MaxUrlCount {
 		ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
@@ -94,9 +97,43 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
+	body.CreatedAt = time.Now().UTC()
+
+	// Insert new URL
+	if _, err := db.NewInsert().Model(&body).Exec(ctx); err != nil {
+		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
+			Message: "Failed to create tiny URL",
+		})
+		return
+	}
+
+	// Increment URL count
+	if err := utils.IncrementURLCount(body.UserID, db, ctx); err != nil {
+		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
+			Message: "Failed to increment URL count: " + err.Error(),
+		})
+		return
+	}
+
+	// Fetch updated count
+	updatedCount, err := db.NewSelect().
+		Model(&models.Tinyurl{}).
+		Where("user_id = ?", body.UserID).
+		Where("is_deleted = ?", false).
+		Count(ctx)
+
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
+			Message: "Failed to fetch updated URL count",
+		})
+		return
+	}
+
 	ctx.JSON(http.StatusOK, dtos.URLCreationResponse{
-		Message:  "Tiny URL created successfully",
-		ShortURL: body.ShortUrl,
+		Message:   "Tiny URL created successfully",
+		ShortURL:  body.ShortUrl,
+		CreatedAt: body.CreatedAt,
+		URLCount:  updatedCount,
 	})
 }
 
@@ -183,20 +220,36 @@ func GetAllURLs(ctx *gin.Context, db *bun.DB) {
 		URLs:    urlDetails,
 	})
 }
+
 func DeleteURL(ctx *gin.Context, db *bun.DB) {
-	id, _ := ctx.Params.Get("id")
-	_, err := db.NewUpdate().Model(&models.Tinyurl{}).Set("is_deleted=?", true).Set("deleted_at=?", time.Now().UTC()).Where("id = ?", id).Exec(ctx)
+    id, _ := ctx.Params.Get("id")
+    _, err := db.NewUpdate().Model(&models.Tinyurl{}).Set("is_deleted=?", true).Set("deleted_at=?", time.Now().UTC()).Where("id = ?", id).Exec(ctx)
 
-	if err != nil {
-		ctx.JSON(http.StatusNotFound, dtos.UserURLsResponse{
-			Message: "No URLs found",
-		})
-		return
-	}
+    if err != nil {
+        ctx.JSON(http.StatusNotFound, dtos.UserURLsResponse{
+            Message: "No URLs found",
+        })
+        return
+    }
 
-	ctx.JSON(http.StatusOK, dtos.UserURLsResponse{
-		Message: "Url deleted",
-	})
+    userID, err := strconv.ParseInt(ctx.PostForm("user_id"), 10, 64)
+    if err != nil {
+        ctx.JSON(http.StatusBadRequest, dtos.UserURLsResponse{
+            Message: "Invalid user ID",
+        })
+        return
+    }
+
+    if err := utils.DecrementURLCount(userID, db, ctx); err != nil {
+        ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
+            Message: "Failed to decrement URL count: " + err.Error(),
+        })
+        return
+    }
+
+    ctx.JSON(http.StatusOK, dtos.UserURLsResponse{
+        Message: "URL deleted",
+    })
 }
 
 func GetURLDetails(ctx *gin.Context, db *bun.DB) {

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -126,7 +126,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 	ctx.JSON(http.StatusOK, dtos.URLCreationResponse{
 		Message:   "Tiny URL created successfully",
 		ShortURL:  body.ShortUrl,
-		CreatedAt: body.CreatedAt,
 		URLCount:  updatedCount,
 	})
 }

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -31,7 +31,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	// Check if URL already exists
 	var existingOriginalURL models.Tinyurl
 	if err := db.NewSelect().Model(&existingOriginalURL).
 		Where("original_url = ?", body.OriginalUrl).
@@ -46,7 +45,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	// Validate custom short URL
 	if body.ShortUrl != "" {
 		if len(body.ShortUrl) < 5 {
 			ctx.JSON(http.StatusBadRequest, dtos.URLCreationResponse{
@@ -76,7 +74,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		}
 	}
 
-	// Count URLs for the user
 	count, err := db.NewSelect().
 		Model(&models.Tinyurl{}).
 		Where("user_id = ?", body.UserID).
@@ -99,7 +96,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 
 	body.CreatedAt = time.Now().UTC()
 
-	// Insert new URL
 	if _, err := db.NewInsert().Model(&body).Exec(ctx); err != nil {
 		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
 			Message: "Failed to create tiny URL",
@@ -107,7 +103,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	// Increment URL count
 	if err := utils.IncrementURLCount(body.UserID, db, ctx); err != nil {
 		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
 			Message: "Failed to increment URL count: " + err.Error(),
@@ -115,7 +110,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	// Fetch updated count
 	updatedCount, err := db.NewSelect().
 		Model(&models.Tinyurl{}).
 		Where("user_id = ?", body.UserID).

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -94,6 +94,15 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
+	body.CreatedAt = time.Now().UTC()
+
+	if _, err := db.NewInsert().Model(&body).Exec(ctx); err != nil {
+		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
+			Message: "Failed to create tiny URL",
+		})
+		return
+	}
+
 	if err := utils.IncrementURLCount(body.UserID, db, ctx); err != nil {
 		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
 			Message: "Failed to increment URL count: " + err.Error(),

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -94,15 +94,6 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	body.CreatedAt = time.Now().UTC()
-
-	if _, err := db.NewInsert().Model(&body).Exec(ctx); err != nil {
-		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
-			Message: "Failed to create tiny URL",
-		})
-		return
-	}
-
 	if err := utils.IncrementURLCount(body.UserID, db, ctx); err != nil {
 		ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
 			Message: "Failed to increment URL count: " + err.Error(),

--- a/dtos/http_response.go
+++ b/dtos/http_response.go
@@ -6,6 +6,7 @@ type URLCreationResponse struct {
 	Message   string    `json:"message"`
 	ShortURL  string    `json:"shortUrl,omitempty"`
 	CreatedAt time.Time `json:"createdAt,omitempty"`
+	URLCount  int       `json:"urlCount"`
 }
 type UserURLsResponse struct {
 	Message string       `json:"message"`

--- a/dtos/http_response.go
+++ b/dtos/http_response.go
@@ -8,6 +8,10 @@ type URLCreationResponse struct {
 	CreatedAt time.Time `json:"createdAt,omitempty"`
 	URLCount  int       `json:"urlCount"`
 }
+type URLDeleteResponse struct{
+	Message   string    `json:"message"`
+	URLCount   int       `json:"urlCount"`
+}
 type UserURLsResponse struct {
 	Message string       `json:"message"`
 	URLs    []URLDetails `json:"urls,omitempty"`

--- a/migrations/20230912194711_init.up.sql
+++ b/migrations/20230912194711_init.up.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE TABLE users (
   id bigserial PRIMARY KEY,
   username varchar(256) UNIQUE NOT NULL,
-  email varchar(256) UNIQUE NOT NULL,
+  email varchar UNIQUE NOT NULL,
   is_verified boolean DEFAULT false,
   password varchar(128) NOT NULL,
   created_at timestamp DEFAULT (NOW() AT TIME ZONE 'UTC'),

--- a/migrations/20230912194711_init.up.sql
+++ b/migrations/20230912194711_init.up.sql
@@ -3,13 +3,14 @@ BEGIN;
 CREATE TABLE users (
   id bigserial PRIMARY KEY,
   username varchar(256) UNIQUE NOT NULL,
-  email varchar UNIQUE NOT NULL,
+  email varchar(256) UNIQUE NOT NULL,
   is_verified boolean DEFAULT false,
   password varchar(128) NOT NULL,
   created_at timestamp DEFAULT (NOW() AT TIME ZONE 'UTC'),
   updated_at timestamp DEFAULT (NOW() AT TIME ZONE 'UTC'),
   is_deleted boolean DEFAULT false,
-  is_onboarding BOOLEAN NOT NULL DEFAULT TRUE
+  is_onboarding BOOLEAN NOT NULL DEFAULT TRUE,
+  url_count int NOT NULL DEFAULT 0
 );
 
 COMMIT;

--- a/models/users.go
+++ b/models/users.go
@@ -18,4 +18,6 @@ type User struct {
 	CreatedAt    time.Time `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"createdAt"`
 	UpdatedAt    time.Time `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updatedAt"`
 	IsDeleted bool `bun:"is_deleted,default:false" json:"isDeleted"`
+	URLCount     int       `bun:"url_count,notnull,default:0" json:"urlCount"`
+	
 }

--- a/tests/integration/url_test.go
+++ b/tests/integration/url_test.go
@@ -122,28 +122,42 @@ func (suite *AppTestSuite) TestCreateTinyURLCustomShortURLExists() {
 }
 
 func (suite *AppTestSuite) TestCreateTinyURLExistingOriginalURL() {
-	router := gin.Default()
-	router.POST("/v1/tinyurl", func(ctx *gin.Context) {
-		controller.CreateTinyURL(ctx, suite.db)
-	})
+    router := gin.Default()
+    router.POST("/v1/tinyurl", func(ctx *gin.Context) {
+        controller.CreateTinyURL(ctx, suite.db)
+    })
 
-	existingOriginalURL := "https://www.example.com/1"
+    existingOriginalURL := "https://www.example.com/1"
 
-	requestBody := map[string]interface{}{
-		"OriginalUrl": existingOriginalURL,
-		"UserId":      1,
-	}
-	requestJSON, _ := json.Marshal(requestBody)
-	req, _ := http.NewRequest("POST", "/v1/tinyurl", bytes.NewBuffer(requestJSON))
-	req.Header.Set("Content-Type", "application/json")
+    requestBody := map[string]interface{}{
+        "OriginalUrl": existingOriginalURL,
+        "UserId":      1,
+    }
+    requestJSON, _ := json.Marshal(requestBody)
+    req, _ := http.NewRequest("POST", "/v1/tinyurl", bytes.NewBuffer(requestJSON))
+    req.Header.Set("Content-Type", "application/json")
 
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+    w := httptest.NewRecorder()
+    router.ServeHTTP(w, req)
 
-	assert.Equal(suite.T(), http.StatusOK, w.Code, "Expected status code to be 200 for existing original URL")
+    assert.Equal(suite.T(), http.StatusOK, w.Code, "Expected status code to be 200 for existing original URL")
 
-	expectedResponse := `{"message":"Shortened URL already exists", "shortUrl":"37fff","createdAt":"0001-01-01T00:00:00Z"}`
-	assert.JSONEq(suite.T(), expectedResponse, w.Body.String(), "Response body does not match expected JSON")
+    var responseBody map[string]interface{}
+    err := json.Unmarshal(w.Body.Bytes(), &responseBody)
+    assert.NoError(suite.T(), err)
+
+    if responseBody["urlCount"] != nil {
+        responseBody["urlCount"] = int(responseBody["urlCount"].(float64))
+    }
+
+    expectedResponse := map[string]interface{}{
+        "message":   "Shortened URL already exists",
+        "shortUrl":  "37fff",
+        "urlCount":  0,
+        "createdAt": responseBody["createdAt"], 
+    }
+
+    assert.Equal(suite.T(), expectedResponse, responseBody, "Response body does not match expected JSON")
 }
 
 // TestRedirectShortURLSuccess tests the successful redirection of a short URL to the original URL.

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -1,10 +1,13 @@
 package tests
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 
 	controller "github.com/Real-Dev-Squad/tiny-site-backend/controllers"
+	"github.com/Real-Dev-Squad/tiny-site-backend/models"
+	"github.com/Real-Dev-Squad/tiny-site-backend/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
@@ -92,3 +95,28 @@ func (suite *AppTestSuite) TestGetSelfUserNonExistingUser() {
 
 	assert.Equal(suite.T(), http.StatusNotFound, w.Code, "Expected status code to be 404 for non-existing user")
 }
+
+func (suite *AppTestSuite) TestIncrementURLCount() {
+	ctx := gin.Context{}
+
+	err := utils.IncrementURLCount(1, suite.db, &ctx)
+	assert.NoError(suite.T(), err)
+
+	user := new(models.User)
+	err = suite.db.NewSelect().Model(user).Where("id = ?", 1).Scan(context.Background())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 1, user.URLCount)
+}
+
+func (suite *AppTestSuite) TestDecrementURLCount() {
+	ctx := gin.Context{}
+
+	err := utils.DecrementURLCount(1, suite.db, &ctx)
+	assert.NoError(suite.T(), err)
+
+	user := new(models.User)
+	err = suite.db.NewSelect().Model(user).Where("id = ?", 1).Scan(context.Background())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, user.URLCount)
+}
+

--- a/tests/integration/users_test.go
+++ b/tests/integration/users_test.go
@@ -97,26 +97,37 @@ func (suite *AppTestSuite) TestGetSelfUserNonExistingUser() {
 }
 
 func (suite *AppTestSuite) TestIncrementURLCount() {
-	ctx := gin.Context{}
-
-	err := utils.IncrementURLCount(1, suite.db, &ctx)
-	assert.NoError(suite.T(), err)
+	ctx, _ := gin.CreateTestContext(nil)
 
 	user := new(models.User)
+	err := suite.db.NewSelect().Model(user).Where("id = ?", 1).Scan(context.Background())
+	assert.NoError(suite.T(), err)
+	user.URLCount = 0
+	_, err = suite.db.NewUpdate().Model(user).WherePK().Column("url_count").Exec(context.Background())
+	assert.NoError(suite.T(), err)
+
+	err = utils.IncrementURLCount(1, suite.db, ctx)
+	assert.NoError(suite.T(), err)
+
 	err = suite.db.NewSelect().Model(user).Where("id = ?", 1).Scan(context.Background())
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 1, user.URLCount)
 }
 
 func (suite *AppTestSuite) TestDecrementURLCount() {
-	ctx := gin.Context{}
-
-	err := utils.DecrementURLCount(1, suite.db, &ctx)
-	assert.NoError(suite.T(), err)
+	ctx, _ := gin.CreateTestContext(nil)
 
 	user := new(models.User)
+	err := suite.db.NewSelect().Model(user).Where("id = ?", 1).Scan(context.Background())
+	assert.NoError(suite.T(), err)
+	user.URLCount = 1
+	_, err = suite.db.NewUpdate().Model(user).WherePK().Column("url_count").Exec(context.Background())
+	assert.NoError(suite.T(), err)
+
+	err = utils.DecrementURLCount(1, suite.db, ctx)
+	assert.NoError(suite.T(), err)
+
 	err = suite.db.NewSelect().Model(user).Where("id = ?", 1).Scan(context.Background())
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 0, user.URLCount)
 }
-

--- a/tests/test-data/init-db.sql
+++ b/tests/test-data/init-db.sql
@@ -10,7 +10,8 @@ CREATE TABLE IF NOT EXISTS users (
   is_deleted boolean DEFAULT false,
   is_onboarding BOOLEAN NOT NULL DEFAULT TRUE,
   created_at timestamp WITH TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC'),
-  updated_at timestamp WITH TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC')
+  updated_at timestamp WITH TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC'),
+  url_count bigint DEFAULT 0
 );
 
 -- Insert data into the users table

--- a/utils/user.go
+++ b/utils/user.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"github.com/Real-Dev-Squad/tiny-site-backend/models"
+	"github.com/gin-gonic/gin"
+	"github.com/uptrace/bun"
+)
+
+func IncrementURLCount(userID int64, db *bun.DB, ctx *gin.Context) error {
+	_, err := db.NewUpdate().
+		Model((*models.User)(nil)).
+		Set("url_count = url_count + 1").
+		Where("id = ?", userID).
+		Exec(ctx)
+	return err
+}
+
+func DecrementURLCount(userID int64, db *bun.DB, ctx *gin.Context) error {
+	_, err := db.NewUpdate().
+		Model((*models.User)(nil)).
+		Set("url_count = url_count - 1").
+		Where("id = ?", userID).
+		Exec(ctx)
+	return err
+}


### PR DESCRIPTION
## Issue Ticket Number

-   closes #101 

## Description

The URL creation endpoint (/create-tinyurl) currently does not include the count of URLs created by a user in its response. This information is valuable for enforcing and communicating URL creation limits to users.

**Breaking Changes**

-   [ ] Yes
-   [x] No

_If your feature introduces breaking changes or if something is missing, please mention the related issue tickets._

**Development Tested?**

-   [x] Yes
-   [ ] No

_Confirm whether the changes have been tested locally during development._

**Tested in Staging?**

-   [x] Yes
-   [ ] No

_Indicate whether the changes have been tested in the staging environment for dev to main._

**Database Changes**

-   [ ] Yes
-   [x] No

_Indicate whether the changes include modifications to the database._

### Screenshots

Attach any relevant screenshots, such as test coverage reports, before and after images, or other visual aids.

## Additional Notes

Include any additional notes, considerations, or explanations that might be helpful for reviewers.
