### PR TITLE
Fix the naming `TOKEN_VALIDITY_IN_SECONDS`

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -67,6 +67,6 @@ jobs:
               -e GOOGLE_CLIENT_SECRET=${{secrets.GOOGLE_CLIENT_SECRET}} \
               -e GOOGLE_REDIRECT_URL=${{vars.GOOGLE_REDIRECT_URL}} \
               -e ALLOWED_ORIGINS=${{vars.ALLOWED_ORIGINS}} \
-              -e TOKEN_VALIDITY_IN_SECOND=${{vars.TOKEN_VALIDITY_IN_SECOND}} \
+              -e TOKEN_VALIDITY_IN_SECONDS=${{vars.TOKEN_VALIDITY_IN_SECONDS}} \
               -e USER_MAX_URL_COUNT=${{vars.USER_MAX_URL_COUNT}} \
               ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}


### PR DESCRIPTION
## Description

In code, env name was `TOKEN_VALIDITY_IN_SECONDS` , and in the CI it was set to `TOKEN_VALIDITY_IN_SECOND` ref: https://github.com/Real-Dev-Squad/tiny-site-backend/issues/110

**Breaking Changes**

-   [ ] Yes
-   [x] No

_If your feature introduces breaking changes or if something is missing, please mention the related issue tickets._

**Development Tested?**

-   [x] Yes
-   [ ] No

_Confirm whether the changes have been tested locally during development._

**Tested in Staging?**

-   [x] Yes
-   [ ] No

_Indicate whether the changes have been tested in the staging environment for dev to main._

**Database Changes**

-   [ ] Yes
-   [x] No

_Indicate whether the changes include modifications to the database._

### Screenshots

Attach any relevant screenshots, such as test coverage reports, before and after images, or other visual aids.

## Additional Notes

Include any additional notes, considerations, or explanations that might be helpful for reviewers.
