### PR TITLE
block domain tiny.realdevsquad.com while creating tiny url

### DIFF
--- a/controllers/url.go
+++ b/controllers/url.go
@@ -111,19 +111,12 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 			
 		path :=parsedUrl.Path
 	
-		existingShortUrlCount, err := db.NewSelect().Model(&models.Tinyurl{}).Where("short_url =? AND is_deleted = ?",path[1:],false).Count(ctx)
-	
-		if err != nil {
-			ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
-				Message: "Failed to check existence of short url",
-			})
-			return
-		}
-	
-		if existingShortUrlCount == 1 {
+		if len(path) >=1  {
+
 			ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
-				Message: "Cannot create tiny url of the existing tiny url!",
+				Message: "Cannot create tiny url of tiny url!",
 			})
+			
 			return
 		}
 	}

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -114,7 +114,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		if len(path) >=1  {
 
 			ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
-				Message: "Cannot create tiny url of tiny url!",
+				Message: "Cannot create a tiny url for tiny.realdevsquad.com",
 			})
 			
 			return

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -114,7 +114,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		if len(path) >=1  {
 
 			ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
-				Message: "Cannot create a tiny url for tiny.realdevsquad.com",
+				Message: "Cannot create a tiny url for " + config.Domain,
 			})
 			
 			return

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -92,11 +93,39 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
+	
 	if count >= config.UserMaxUrlCount {
 		ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
 			Message: "You've reached the limit of " + strconv.Itoa(config.UserMaxUrlCount) + " for URLs. Delete one to add a new one !!",
 		})
 		return
+	}
+	
+	parsedUrl,err := url.Parse(body.OriginalUrl);
+
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(strings.ToLower(parsedUrl.Host),strings.ToLower(config.Domain)) {
+			
+		path :=parsedUrl.Path
+	
+		existingShortUrlCount, err := db.NewSelect().Model(&models.Tinyurl{}).Where("short_url =? AND is_deleted = ?",path[1:],false).Count(ctx)
+	
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, dtos.URLCreationResponse{
+				Message: "Failed to check existence of short url",
+			})
+			return
+		}
+	
+		if existingShortUrlCount == 1 {
+			ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
+				Message: "Cannot create tiny url of the existing tiny url!",
+			})
+			return
+		}
 	}
 
 	newTinyURL := models.Tinyurl{

--- a/tests/integration/url_test.go
+++ b/tests/integration/url_test.go
@@ -247,3 +247,27 @@ func (suite *AppTestSuite) TestGetURLDetailsSuccess() {
 	// Assert the status code is 200 for successful retrieval of URL details
 	assert.Equal(suite.T(), http.StatusOK, w.Code, "Expected status code to be 200 for successful retrieval of URL details")
 }
+
+//TestForbidTinyURLChaining forbids the creation of tiny url of existing tiny url
+func (suite *AppTestSuite) TestForbidTinyURLChaining() {
+
+	router := gin.Default()
+	router.POST("/v1/tinyurl", func(ctx *gin.Context) {
+		controller.CreateTinyURL(ctx, suite.db)
+	})
+
+	requestBody := map[string]interface{}{
+		"OriginalUrl": "https://localhost:8000/abcde",
+		"UserId":      1,
+	}
+
+	requestJSON, _ := json.Marshal(requestBody)
+    req, _ := http.NewRequest("POST", "/v1/tinyurl", bytes.NewBuffer(requestJSON))
+    req.Header.Set("Content-Type", "application/json")
+
+    w := httptest.NewRecorder()
+    router.ServeHTTP(w, req)
+
+	assert.Equal(suite.T(), http.StatusForbidden, w.Code, "Expected status code to be 403 for restricting chaining of tiny urls")
+
+}

--- a/tests/integration/url_test.go
+++ b/tests/integration/url_test.go
@@ -251,7 +251,13 @@ func (suite *AppTestSuite) TestGetURLDetailsSuccess() {
 //TestForbidTinyURLChaining forbids the creation of tiny url of existing tiny url
 func (suite *AppTestSuite) TestForbidTinyURLChaining() {
 
-	router := gin.Default()
+	router := gin.Default();
+
+	router.Use(func(ctx *gin.Context) {
+		ctx.Set("userID", int64(1))
+		ctx.Next()
+	})
+
 	router.POST("/v1/tinyurl", func(ctx *gin.Context) {
 		controller.CreateTinyURL(ctx, suite.db)
 	})


### PR DESCRIPTION
## Issue Ticket Number

This PR takes care of #131 

## Description

Changes in this PR will not let a user create a tiny url of the active tiny url

**Breaking Changes**

-   [ ] Yes
-   [x] No

_If your feature introduces breaking changes or if something is missing, please mention the related issue tickets._

**Development Tested?**

-   [x] Yes
-   [ ] No

_Confirm whether the changes have been tested locally during development._

**Tested in Staging?**

-   [ ] Yes
-   [x] No

_Indicate whether the changes have been tested in the staging environment for dev to main._

**Database Changes**

-   [ ] Yes
-   [x] No

_Indicate whether the changes include modifications to the database._

### Screenshots


https://github.com/user-attachments/assets/8b716b87-6e33-4980-8e8b-9dcf991af131



## Additional Notes

Include any additional notes, considerations, or explanations that might be helpful for reviewers.
