### PR TITLE
Fix: block tiny url domain while creating tiny url

### DIFF
--- a/config/core-config.go
+++ b/config/core-config.go
@@ -26,6 +26,7 @@ var (
 	JwtIssuer            string
 	AllowedOrigin        string
 	Port                 string
+	WebAppBaseDomain     string
 )
 
 func findAndLoadEnv(envFile string) error {
@@ -108,6 +109,8 @@ func loadConfig() {
 
 	Port = getEnvVar("PORT")
 	JwtValidity = getEnvInt("JWT_VALIDITY_IN_HOURS")
+
+	WebAppBaseDomain = getEnvVar("WEB_APP_BASE_URL")
 }
 
 func getEnvVar(key string) string {

--- a/config/core-config.go
+++ b/config/core-config.go
@@ -26,7 +26,7 @@ var (
 	JwtIssuer            string
 	AllowedOrigin        string
 	Port                 string
-	WebAppBaseDomain     string
+	WebAppBaseUrl     string
 )
 
 func findAndLoadEnv(envFile string) error {
@@ -110,7 +110,7 @@ func loadConfig() {
 	Port = getEnvVar("PORT")
 	JwtValidity = getEnvInt("JWT_VALIDITY_IN_HOURS")
 
-	WebAppBaseDomain = getEnvVar("WEB_APP_BASE_URL")
+	WebAppBaseUrl = getEnvVar("WEB_APP_BASE_URL")
 }
 
 func getEnvVar(key string) string {

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -107,7 +107,13 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	if strings.Contains(strings.ToLower(parsedUrl.Host),strings.ToLower(config.Domain)) {
+	parseConfig,err := url.Parse(config.Domain);
+
+	if err != nil {
+		return;
+	}
+
+	if strings.Contains(strings.ToLower(parsedUrl.Host),strings.ToLower(parseConfig.Host)) {
 			
 		path :=parsedUrl.Path
 	

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -107,7 +107,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	parseConfig,err := url.Parse(config.Domain);
+	parseConfig,err := url.Parse(config.WebAppBaseDomain);
 
 	if err != nil {
 		return;
@@ -120,7 +120,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		if len(path) >=1  {
 
 			ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
-				Message: "Cannot create a tiny url for " + config.Domain,
+				Message: "Cannot create a tiny url for " + config.WebAppBaseDomain,
 			})
 			
 			return

--- a/controllers/url.go
+++ b/controllers/url.go
@@ -107,7 +107,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		return
 	}
 
-	parseConfig,err := url.Parse(config.WebAppBaseDomain);
+	parseConfig,err := url.Parse(config.WebAppBaseUrl);
 
 	if err != nil {
 		return;
@@ -120,7 +120,7 @@ func CreateTinyURL(ctx *gin.Context, db *bun.DB) {
 		if len(path) >=1  {
 
 			ctx.JSON(http.StatusForbidden, dtos.URLCreationResponse{
-				Message: "Cannot create a tiny url for " + config.WebAppBaseDomain,
+				Message: "Cannot create a tiny url for " + config.WebAppBaseUrl,
 			})
 			
 			return

--- a/environments/test.env
+++ b/environments/test.env
@@ -6,6 +6,8 @@ JWT_ISSUER="tiny-site-backend"
 DOMAIN="localhost"
 AUTH_REDIRECT_URL="http://localhost:3000"
 
+WEB_APP_BASE_URL='http://localhost:3000'
+
 DB_URL="postgresql://postgres:postgres@localhost:5432/tiny-site?sslmode=disable"
 TEST_DB_URL="postgresql://postgres:postgres@localhost:5432/tiny-site-test?sslmode=disable"
 DB_MAX_OPEN_CONNECTIONS=10

--- a/tests/integration/url_test.go
+++ b/tests/integration/url_test.go
@@ -263,7 +263,7 @@ func (suite *AppTestSuite) TestForbidTinyURLChaining() {
 	})
 
 	requestBody := map[string]interface{}{
-		"OriginalUrl": "https://localhost:8000/abcde",
+		"OriginalUrl": "https://localhost:3000/abcde",
 		"UserId":      1,
 	}
 


### PR DESCRIPTION
## Issue Ticket Number

- Closes #131 

## Description

The config.Domain variable contains http scheme also in the string, because of which the tiny site domain is bypassing the check. After parsing the config.Domain, this should work

**Breaking Changes**

-   [ ] Yes
-   [x] No

_If your feature introduces breaking changes or if something is missing, please mention the related issue tickets._

**Development Tested?**

-   [x] Yes
-   [ ] No

_Confirm whether the changes have been tested locally during development._

**Tested in Staging?**

-   [x] Yes
-   [ ] No

_Indicate whether the changes have been tested in the staging environment for dev to main._

**Database Changes**

-   [ ] Yes
-   [x] No

_Indicate whether the changes include modifications to the database._

### Screenshots

Attach any relevant screenshots, such as test coverage reports, before and after images, or other visual aids.

## Additional Notes

Include any additional notes, considerations, or explanations that might be helpful for reviewers.
